### PR TITLE
Optimize is_in_range() and is_not_in_range()

### DIFF
--- a/addons/WAT/core/assertions/range.gd
+++ b/addons/WAT/core/assertions/range.gd
@@ -3,7 +3,7 @@ extends "assertion.gd"
 static func is_in_range(value, low, high, context: String) -> Dictionary:
 	var passed: String = "%s is in range(%s, %s)" % [value, low, high]
 	var failed: String = "%s is not in range(%s, %s)" % [value, low, high]
-	var success = value in range(low, high)
+	var success = low <= value and value < high
 	var expected = passed
 	var result = passed if success else failed
 	return _result(success, expected, result, context)
@@ -11,7 +11,7 @@ static func is_in_range(value, low, high, context: String) -> Dictionary:
 static func is_not_in_range(value, low, high, context: String) -> Dictionary:
 	var passed: String = "%s is not in range(%s, %s)" % [value, low, high]
 	var failed: String = "%s is in range(%s, %s)" % [value, low, high]
-	var success = not value in range(low, high)
+	var success = low > value or value >= high
 	var expected = passed
 	var result = passed if success else failed
 	return _result(success, expected, result, context)


### PR DESCRIPTION
GDScript's range() function creates an Array every time it's called, so
(especially for large ranges) it's more efficient to avoid calling
range().

I used this script to benchmark my change:
```
extends WAT.Test


func test_is_in_range():
	var i = 0
	while i < 350:
		asserts.is_in_range(i, 0, 1000000)
		asserts.is_not_in_range(-i, -1, -1000001)
		i += 1
```
On my machine, that test takes between 6 and 7 seconds to run with the old versions of is_in_range() and is_not_in_range(). That test takes less than 1 second to run with the new versions of is_in_range() and is_not_in_range().