### PR TITLE
Remove stored default editor theme and make SpinBox in UI dynamically sized

### DIFF
--- a/addons/WAT/gui.tscn
+++ b/addons/WAT/gui.tscn
@@ -1,26 +1,20 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://addons/WAT/ui/scripts/gui.gd" type="Script" id=1]
-[ext_resource path="res://addons/WAT/assets/default_theme.tres" type="Theme" id=2]
 [ext_resource path="res://addons/WAT/ui/scenes/Core.tscn" type="PackedScene" id=3]
-
-[sub_resource type="StyleBoxFlat" id=1]
-content_margin_left = 10.0
-content_margin_right = 10.0
-content_margin_top = 10.0
-content_margin_bottom = 10.0
-bg_color = Color( 0.2, 0.231373, 0.309804, 1 )
 
 [node name="Tests" type="PanelContainer"]
 anchor_right = 1.0
 anchor_bottom = 1.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-theme = ExtResource( 2 )
-custom_styles/panel = SubResource( 1 )
 script = ExtResource( 1 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="Core" parent="." instance=ExtResource( 3 )]
+margin_left = 7.0
+margin_top = 7.0
+margin_right = 1017.0
+margin_bottom = 593.0

--- a/addons/WAT/ui/scenes/RunSettings.tscn
+++ b/addons/WAT/ui/scenes/RunSettings.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://addons/WAT/ui/scripts/run_settings.gd" type="Script" id=1]
+[ext_resource path="res://addons/WAT/ui/scripts/dynamic_size_spinbox.gd" type="Script" id=2]
 
 [node name="RunSettings" type="HBoxContainer"]
 margin_left = 267.0
@@ -20,6 +21,7 @@ size_flags_vertical = 0
 align = 1
 prefix = "Repeat"
 suffix = "Time(s)"
+script = ExtResource( 2 )
 
 [node name="Threads" type="SpinBox" parent="."]
 margin_left = 154.0
@@ -29,8 +31,9 @@ rect_min_size = Vector2( 160, 0 )
 size_flags_horizontal = 0
 size_flags_vertical = 0
 min_value = 1.0
-max_value = 7.0
+max_value = 31.0
 value = 1.0
 align = 1
 prefix = "Run on"
 suffix = "Thread(s)"
+script = ExtResource( 2 )

--- a/addons/WAT/ui/scripts/dynamic_size_spinbox.gd
+++ b/addons/WAT/ui/scripts/dynamic_size_spinbox.gd
@@ -1,0 +1,56 @@
+extends SpinBox
+tool
+
+var oldText
+
+func _ready():
+	get_line_edit().expand_to_text_length = true
+	get_line_edit().connect("text_changed", self, "_on_text_edit_changed")
+	get_line_edit().connect("focus_exited", self, "_on_focus_exited")
+	connect("value_changed", self, "_on_value_changed")
+	oldText = get_line_edit().text
+
+func _on_focus_exited():
+	# Disgusting frame waiting workaround because there is currently no way to 
+	# listen for when a spinbox is changed and the change is rejected.
+	# (ie. inputting 20 in the spinbox when the spinbox already has a value of 20)
+	yield(get_tree(),"idle_frame")
+	yield(get_tree(),"idle_frame")
+	set_size(get_minimum_size())
+	pass
+
+func _on_value_changed(newValue):
+	set_size(get_minimum_size())
+	
+func _on_text_edit_changed(newText):
+	# Using regex since you cannot reliably detect if a string is not an int
+	# (ie. String(invalid text) = 0, when 0 might be a value we want)
+	var regex = RegEx.new()
+	regex.compile("^(0|[1-9][0-9]*)$")
+	
+	# Remove prefix and suffixes
+	newText = newText.trim_prefix(prefix + " ").trim_suffix(" " + suffix)
+	
+	# Try and parse the inputted text in the middle
+	var result = regex.search(newText)
+	var invalidInput = false
+	
+	# If input is not an integer (excluding empty input), then revert the input back
+	if not newText.empty() and not result:
+		get_line_edit().text = oldText
+		invalidInput = true
+	# If input is out of bounds, bring it back to the nearest bound  
+	elif result:
+		if int(result.get_string()) > max_value:
+			get_line_edit().text = str(max_value)
+			get_line_edit().caret_position = get_line_edit().text.length()
+			invalidInput = true
+		elif int(result.get_string()) < min_value:
+			get_line_edit().text = str(min_value)
+			get_line_edit().caret_position = get_line_edit().text.length()
+			invalidInput = true
+	
+	if not invalidInput:
+		oldText = prefix + " " + newText + " " + suffix
+	
+	set_size(get_minimum_size())

--- a/addons/WAT/ui/scripts/dynamic_size_spinbox.gd
+++ b/addons/WAT/ui/scripts/dynamic_size_spinbox.gd
@@ -9,6 +9,10 @@ func _ready():
 	get_line_edit().connect("focus_exited", self, "_on_focus_exited")
 	connect("value_changed", self, "_on_value_changed")
 	oldText = get_line_edit().text
+	
+	# Set's the text to itself in order to shoot an update to the line edit
+	# This is needed or else the line edit starts off off-centered at startup
+	get_line_edit().text = oldText
 
 func _on_focus_exited():
 	# Disgusting frame waiting workaround because there is currently no way to 

--- a/project.godot
+++ b/project.godot
@@ -64,4 +64,4 @@ config/icon="res://icon.png"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "WAT" )
+enabled=PoolStringArray( "res://addons/WAT/plugin.cfg" )


### PR DESCRIPTION
The default editor theme that is stored within `gui.tscn` has been removed. This lets the Tests menu adopt the Godot editor's current theme, which lets the Tests menu use a custom editor theme if there is any.

The `SpinBox` used in the UI has been extended to dynamically resize according to its `LineEdit` content. This feature would make the UI function better in high DPI monitors since the current use of `Min Size` for expanding the `SpinBox` only works well on regular monitors -- the `SpinBox` becomes too small on high DPI monitors and obscures the text, making it hard to see how many threads and how many repeats are set.