### PR TITLE
Add icon scaling for "Select Test" options menu & disable "Run Debug" on standalone builds of Tests UI

### DIFF
--- a/addons/WAT/ui/scenes/Menu.tscn
+++ b/addons/WAT/ui/scenes/Menu.tscn
@@ -18,10 +18,10 @@
 
 [sub_resource type="StyleBoxEmpty" id=5]
 
-[sub_resource type="InputEventKey" id=8]
+[sub_resource type="InputEventKey" id=6]
 
 [sub_resource type="ShortCut" id=7]
-shortcut = SubResource( 8 )
+shortcut = SubResource( 6 )
 
 [node name="Menu" type="HBoxContainer"]
 margin_right = 1004.0

--- a/addons/WAT/ui/scripts/gui.gd
+++ b/addons/WAT/ui/scripts/gui.gd
@@ -8,6 +8,7 @@ const Log: Script = preload("res://addons/WAT/log.gd")
 const TestRunner: Script = preload("res://addons/WAT/core/test_runner/test_runner.gd")
 const Server: Script = preload("res://addons/WAT/network/server.gd")
 const XML: Script = preload("res://addons/WAT/editor/junit_xml.gd")
+const PluginAssetsRegistry: Script = preload("res://addons/WAT/ui/scripts/plugin_assets_registry.gd")
 onready var TestMenu: Button = $Core/Menu/TestMenu
 onready var Results: TabContainer = $Core/Results
 onready var Summary: HBoxContainer = $Core/Summary
@@ -20,6 +21,10 @@ signal function_selected
 func _ready() -> void:
 	if not Engine.is_editor_hint():
 		_set_window_size()
+		# No argument makes the AssetsRegistry default to a scale of 1, which
+		# should make every icon look normal when the Tests UI launches
+		# outside of the editor.
+		_setup_editor_assets(PluginAssetsRegistry.new())
 	$Core.connect("test_strategy_set", self, "_on_test_strategy_set")
 	Results.connect("function_selected", self, "_on_function_selected")
 	

--- a/addons/WAT/ui/scripts/menu.gd
+++ b/addons/WAT/ui/scripts/menu.gd
@@ -3,8 +3,14 @@ tool
 
 onready var QuickRunAll: Button = $QuickRunAll
 onready var QuickRunAllDebug: Button = $QuickRunAllDebug
+onready var TestMenu: Button = $TestMenu
+
+func _ready():
+	if not Engine.is_editor_hint():
+		QuickRunAllDebug.disabled = true
 
 # Loads scaled assets like icons and fonts
 func _setup_editor_assets(assets_registry):
+	TestMenu._setup_editor_assets(assets_registry)
 	QuickRunAll.icon = assets_registry.load_asset(QuickRunAll.icon)
 	QuickRunAllDebug.icon = assets_registry.load_asset(QuickRunAllDebug.icon)

--- a/addons/WAT/ui/scripts/plugin_assets_registry.gd
+++ b/addons/WAT/ui/scripts/plugin_assets_registry.gd
@@ -70,7 +70,7 @@ func _calculate_current_editor_scale_3_1():
 	var display_scale: int = editor_settings.get_setting("interface/editor/display_scale")
 	var custom_display_scale: float = editor_settings.get_setting("interface/editor/custom_display_scale")
 
-	match (display_scale):
+	match display_scale:
 		0:
 			if OS.get_name() == "OSX":
 				return OS.get_screen_max_scale()

--- a/addons/WAT/ui/scripts/plugin_assets_registry.gd
+++ b/addons/WAT/ui/scripts/plugin_assets_registry.gd
@@ -11,7 +11,7 @@ var plugin: EditorPlugin
 # do not duplicate the same asset multiple times.  
 var loaded_editor_assets: Dictionary
 
-func _init(plugin_: EditorPlugin):
+func _init(plugin_ = null):
 	plugin = plugin_
 
 # Returns an asset scaled to fit the current editor's UI scale
@@ -49,4 +49,6 @@ func _load_scaled_font(font: Font) -> DynamicFont:
 	return duplicate
 	
 func get_editor_scale():
+	if plugin == null:
+		return 1
 	return plugin.get_editor_interface().get_editor_scale()

--- a/addons/WAT/ui/scripts/plugin_assets_registry.gd
+++ b/addons/WAT/ui/scripts/plugin_assets_registry.gd
@@ -54,26 +54,29 @@ func _load_scaled_font(font: Font) -> DynamicFont:
 func get_editor_scale():
 	if plugin == null:
 		return 1
-	if Engine.get_version_info().minor > 2:
+	if Engine.get_version_info().minor >= 3:
 		return plugin.get_editor_interface().get_editor_scale()
 	else:
 		if _cached_editor_scale == -1:
-			_cached_editor_scale = _calculate_current_editor_scale()
+			if Engine.get_version_info().minor >= 1:
+				_cached_editor_scale = _calculate_current_editor_scale_3_1()
+			else:
+				_cached_editor_scale = _calculate_current_editor_scale_3_0()
 		return _cached_editor_scale
 
-func _calculate_current_editor_scale():
+func _calculate_current_editor_scale_3_1():
 	var editor_settings = plugin.get_editor_interface().get_editor_settings()
 	
-	var display_scale_type: int = editor_settings.get_setting("interface/editor/display_scale")
+	var display_scale: int = editor_settings.get_setting("interface/editor/display_scale")
 	var custom_display_scale: float = editor_settings.get_setting("interface/editor/custom_display_scale")
 
-	match (display_scale_type):
+	match (display_scale):
 		0:
 			if OS.get_name() == "OSX":
 				return OS.get_screen_max_scale()
 			else:
-				var curr_screen: int = OS.get_current_screen()
-				if OS.get_screen_dpi(curr_screen) >= 192 and OS.get_screen_size(curr_screen).x > 2000:
+				var screen: int = OS.get_current_screen()
+				if OS.get_screen_dpi(screen) >= 192 and OS.get_screen_size(screen).x > 2000:
 					return 2.0
 				else:
 					return 1.0
@@ -91,3 +94,24 @@ func _calculate_current_editor_scale():
 			return 2.0
 		_:
 			return custom_display_scale
+
+func _calculate_current_editor_scale_3_0():
+	var editor_settings = plugin.get_editor_interface().get_editor_settings()
+	
+	var dpi_mode = editor_settings.get_settings("interface/editor/hidpi_mode")
+	
+	match dpi_mode:
+		0:
+			var screen: int = OS.get_current_screen()
+			if OS.get_screen_dpi(screen) >= 192 and OS.get_screen_size(screen).x > 2000:
+				return 2.0
+			else:
+				return 1.0
+		1:
+			return 0.75
+		2:
+			return 1.0
+		3:
+			return 1.5
+		4:
+			return 2.0

--- a/addons/WAT/ui/scripts/test_menu.gd
+++ b/addons/WAT/ui/scripts/test_menu.gd
@@ -2,6 +2,13 @@ extends Button
 tool
 
 enum { RUN_ALL, RUN_DIR, RUN_SCRIPT, RUN_TAG, RUN_METHOD, RUN_FAILURES }
+var FOLDER_ICON: Texture
+var FAILED_ICON: Texture
+var SCRIPT_ICON: Texture
+var PLAY_ICON: Texture
+var PLAY_DEBUG_ICON: Texture
+var LABEL_ICON: Texture
+var FUNCTION_ICON: Texture
 const TestGatherer: Script = preload("res://addons/WAT/editor/test_gatherer.gd")
 const ABOUT_TO_SHOW: String = "about_to_show"
 const IDX_PRESSED: String = "index_pressed"
@@ -95,19 +102,21 @@ func _on_dirs_about_to_show() -> void:
 	Directories.clear()
 	Directories.set_as_minsize()
 	Directories.add_item("Run All")
-	Directories.set_item_icon(0, load("res://addons/WAT/assets/play.png"))
+	Directories.set_item_icon(0, PLAY_ICON)
 	Directories.add_item("Run With Debug")
-	Directories.set_item_icon(1, load("res://addons/WAT/assets/play_debug.png"))
+	Directories.set_item_icon(1, PLAY_DEBUG_ICON)
 	Directories.add_item("Rerun Failures")
-	Directories.set_item_icon(2, load("res://addons/WAT/assets/failed.png"))
+	Directories.set_item_icon(2, FAILED_ICON)
 	Directories.add_item("Rerun Failures With Debug")
-	Directories.set_item_icon(3, load("res://addons/WAT/assets/failed.png"))
+	Directories.set_item_icon(3, FAILED_ICON)
 	Directories.add_submenu_item("Tags", "Tags")
-	Directories.set_item_icon(4, load("res://addons/WAT/assets/label.png"))
+	Directories.set_item_icon(4, LABEL_ICON)
 	Directories.set_item_metadata(0, {command = RUN_ALL, run_in_editor = true})
 	Directories.set_item_metadata(1, {command = RUN_ALL, run_in_editor = false})
 	Directories.set_item_metadata(2, {command = RUN_FAILURES, run_in_editor = true})
 	Directories.set_item_metadata(3, {command = RUN_FAILURES, run_in_editor = false})
+	if not Engine.is_editor_hint():
+		Directories.set_item_disabled(1, true)
 	var dirs: Array = test.dirs
 	if dirs.empty():
 		return
@@ -120,7 +129,7 @@ func _on_dirs_about_to_show() -> void:
 			script.name = idx as String
 			Directories.add_child(script, true)
 			Directories.add_submenu_item(dir, idx as String, idx)
-			Directories.set_item_icon(idx, load("res://addons/WAT/assets/folder.png"))
+			Directories.set_item_icon(idx, FOLDER_ICON)
 			script.connect(ABOUT_TO_SHOW, self, "_on_scripts_about_to_show", [script])
 			idx += 1
 	
@@ -132,12 +141,13 @@ func _on_scripts_about_to_show(scripts) -> void:
 	scripts.add_item("Run All")
 	var currentdir: String = Directories.get_item_text(scripts.name as int)
 	scripts.set_item_metadata(0, {command = RUN_DIR, path = currentdir, run_in_editor = true})
-	scripts.set_item_icon(0,load("res://addons/WAT/assets/folder.png"))
+	scripts.set_item_icon(0,FOLDER_ICON)
 	
-
 	scripts.add_item("Run All With Debug")
 	scripts.set_item_metadata(1, {command = RUN_DIR, path = currentdir, run_in_editor = false})
-	scripts.set_item_icon(1, load("res://addons/WAT/assets/play_debug.png"))
+	scripts.set_item_icon(1, PLAY_DEBUG_ICON)
+	if not Engine.is_editor_hint():
+		scripts.set_item_disabled(1, true)
 	
 	var scriptlist: Array = test[currentdir]
 	if scriptlist.empty():
@@ -152,7 +162,7 @@ func _on_scripts_about_to_show(scripts) -> void:
 		method.name = idx as String
 		scripts.add_child(method, true)
 		scripts.add_submenu_item(script["path"], method.name, idx)
-		scripts.set_item_icon(idx, load("res://addons/WAT/assets/script.png"))
+		scripts.set_item_icon(idx, SCRIPT_ICON)
 		method.connect(ABOUT_TO_SHOW, self, "_on_methods_about_to_show", [method, scripts])
 		idx += 1
 	
@@ -172,9 +182,11 @@ func _on_methods_about_to_show(methods, scripts) -> void:
 	methods.set_item_metadata(0, {command = RUN_SCRIPT, path = currentScript, run_in_editor = true})
 	methods.set_item_metadata(1, {command = RUN_SCRIPT, path = currentScript, run_in_editor = false})
 	methods.set_item_metadata(2, {command = RUN_TAG, tag = "?"})
-	methods.set_item_icon(0, load("res://addons/WAT/assets/script.png"))
-	methods.set_item_icon(1, load("res://addons/WAT/assets/play_debug.png"))
-	methods.set_item_icon(2, load("res://addons/WAT/assets/label.png"))
+	methods.set_item_icon(0, SCRIPT_ICON)
+	methods.set_item_icon(1, PLAY_DEBUG_ICON)
+	methods.set_item_icon(2, LABEL_ICON)
+	if not Engine.is_editor_hint():
+		methods.set_item_disabled(1, true)
 	var script: GDScript = test.scripts[currentScript]["script"]
 	var methodlist = script.get_script_method_list()
 	var idx: int = methods.get_item_count()
@@ -182,11 +194,11 @@ func _on_methods_about_to_show(methods, scripts) -> void:
 		if method.name.begins_with("test"):
 			methods.add_item(method.name)
 			methods.set_item_metadata(idx, {command = RUN_METHOD, path = script.get_path(), method = method.name, run_in_editor = true})
-			methods.set_item_icon(idx, load("res://addons/WAT/assets/function.png"))
+			methods.set_item_icon(idx, FUNCTION_ICON)
 			idx += 1
 			methods.add_item(method.name + " (Debug) ")
 			methods.set_item_metadata(idx, {command = RUN_METHOD, path = script.get_path(), method = method.name, run_in_editor = false})
-			methods.set_item_icon(idx, load("res://addons/WAT/assets/function.png"))
+			methods.set_item_icon(idx, FUNCTION_ICON)
 			idx += 1
 	
 func _on_tags_about_to_show() -> void:
@@ -350,3 +362,13 @@ func _add_test_dirs_recursively(path: String) -> void:
 		subdirs.append(title)
 	for subdir in subdirs:
 		_add_test_dirs_recursively(subdir)
+
+# Loads scaled assets like icons and fonts
+func _setup_editor_assets(assets_registry):
+	FOLDER_ICON = assets_registry.load_asset("assets/folder.png")
+	FAILED_ICON = assets_registry.load_asset("assets/failed.png")
+	SCRIPT_ICON = assets_registry.load_asset("assets/script.png")
+	PLAY_ICON = assets_registry.load_asset("assets/play.png")
+	PLAY_DEBUG_ICON = assets_registry.load_asset("assets/play_debug.png")
+	LABEL_ICON = assets_registry.load_asset("assets/label.png")
+	FUNCTION_ICON = assets_registry.load_asset("assets/function.png")

--- a/project.godot
+++ b/project.godot
@@ -64,4 +64,4 @@ config/icon="res://icon.png"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "res://addons/WAT/plugin.cfg" )
+enabled=PoolStringArray( "WAT" )

--- a/tests/results.xml
+++ b/tests/results.xml
@@ -1,222 +1,32 @@
 <?xml version="1.0" ?>
-<testsuites failures="0" name="TestXML" tests="22" time="0">
-	<testsuite name="" failures="0"  tests="1" time="0">
-		<testcase name=" default arguments of interpolate property" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given is_on_floor" failures="0"  tests="3" time="0">
-		<testcase name="From a user-defined script" time="0"></testcase>
-		<testcase name="From a built-in KinematicBody2D2" time="0"></testcase>
-		<testcase name="From a child node of a scene without scripts" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Scene Director" failures="0"  tests="5" time="0">
-		<testcase name="When we create two of it for the same scene" time="0"></testcase>
-		<testcase name="When we call a method from a child node that we stubbed" time="0"></testcase>
-		<testcase name="When we add it to the tree it runs" time="0"></testcase>
-		<testcase name="When we call a method from a grandchild node that we stubbed" time="0"></testcase>
-		<testcase name="When we call a method from the root node that we stubbed" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Script Director" failures="0"  tests="3" time="0">
-		<testcase name="When we create two of it for the same script" time="0"></testcase>
-		<testcase name="When we double an inner class" time="0"></testcase>
-		<testcase name="When we call the double the second time" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Test Double" failures="0"  tests="19" time="0">
-		<testcase name="When we call an add(x, y) method that we haven't directed" time="0"></testcase>
-		<testcase name="When we call a method that we have stubbed to return a node" time="0"></testcase>
-		<testcase name="When we call a method that we are spying on" time="0"></testcase>
-		<testcase name="When we call a method that was stubbed to return different values based on argument patterns" time="0"></testcase>
-		<testcase name="When we call a method that was stubbed with a partial (ie using any()) argument pattern" time="0"></testcase>
-		<testcase name="When we call a method that we stubbed to call its super implementation by default" time="0"></testcase>
-		<testcase name="When we stub a method of a doubled inner class" time="0"></testcase>
-		<testcase name="When we stubbed a keyworded method by passing in the correct keyword" time="0"></testcase>
-		<testcase name="When we pass in dependecies on double" time="0"></testcase>
-		<testcase name="When we call a method that was stubbed with an argument pattern that includes a non-primitive object" time="0"></testcase>
-		<testcase name="When we call a method that we have stubbed to return true" time="0"></testcase>
-		<testcase name="When we pass arguments to a method call that we are spying on" time="0"></testcase>
-		<testcase name="When we call a method that we have dummied" time="0"></testcase>
-		<testcase name="When we add an doubled inner class to it" time="0"></testcase>
-		<testcase name="When we double an inner class" time="0"></testcase>
-		<testcase name="When we pass in dependecies on direct" time="0"></testcase>
-		<testcase name="When we pass an Object with a call_func function" time="0"></testcase>
-		<testcase name="When we pass a funcref as a subcall" time="0"></testcase>
-		<testcase name="When we pass a funcref as a subcall that returns" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="" failures="0"  tests="1" time="0">
-		<testcase name=" assert that" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Boolean Assertion" failures="0"  tests="2" time="0">
-		<testcase name="When calling asserts.is_true(true)" time="0"></testcase>
-		<testcase name="When calling asserts.is_false(false)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given an Equality Assertion" failures="0"  tests="7" time="0">
-		<testcase name="When calling asserts.is_less_than(2, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_or_greater_than(2, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal(1, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_greater_than(2, 1)" time="0"></testcase>
-		<testcase name="When callign asserts.is_not_equal(5, 6)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_or_greater_than(1, 1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_equal_or_less_than(1, 1)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="" failures="0"  tests="1" time="0">
-		<testcase name=" simple" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given A File Assertion" failures="0"  tests="3" time="0">
-		<testcase name="When calling asserts.file_does_not_exist when there is no file" time="0"></testcase>
-		<testcase name="When calling asserts file does not exist when path is empty" time="0"></testcase>
-		<testcase name="When calling asserts.file_exists when the file is this suite" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="" failures="0"  tests="5" time="0">
-		<testcase name=" array does not have value" time="0"></testcase>
-		<testcase name=" dict has key" time="0"></testcase>
-		<testcase name=" array has value" time="0"></testcase>
-		<testcase name=" dict does not have key" time="0"></testcase>
-		<testcase name=" dict does not have value" time="0"></testcase>
-	</testsuite>
-
+<testsuites failures="0" name="TestXML" tests="1" time="0">
 	<testsuite name="Given an Is Instance of class/type Assertion" failures="0"  tests="26" time="0">
-		<testcase name="When calling asserts.is_Array(array: Array)" time="0"></testcase>
-		<testcase name="When calling asserts.is_basis(basis: Basis" time="0"></testcase>
-		<testcase name="When calling asserts.is_AABB(aabb: AABB)" time="0"></testcase>
-		<testcase name="When calling asserts.is_bool(true)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Dictionary({})" time="0"></testcase>
-		<testcase name="When calling asserts.is_float(1.0)" time="0"></testcase>
-		<testcase name="When calling asserts.is_color(color: Color)" time="0"></testcase>
-		<testcase name="When callign asserts.is_int(1)" time="0"></testcase>
 		<testcase name="When calling asserts.is_NodePath(@'Parent/Child')" time="0"></testcase>
-		<testcase name="When calling asserts.is_Rect2(rect2: Rect2)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolStringArray(strs: PoolStringArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_string(strs: String)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Quat(quat: Quat)" time="0"></testcase>
+		<testcase name="When calling is asserts.object(node: Node)" time="0"></testcase>
 		<testcase name="When calling is asserts.is_PoolRealArray(reals: PoolRealArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Transform(transform2D: Transform2D)" time="0"></testcase>
+		<testcase name="When calling asserts.is_color(color: Color)" time="0"></testcase>
+		<testcase name="When calling asserts.is_basis(basis: Basis" time="0"></testcase>
+		<testcase name="When calling asserts.is_float(1.0)" time="0"></testcase>
+		<testcase name="When callign asserts.is_int(1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Array(array: Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Plane(plane: Plane())" time="0"></testcase>
+		<testcase name="When calling asserts.is_bool(true)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolByteArray(bytes: PoolByteArray)" time="0"></testcase>
 		<testcase name="When calling asserts.is_PoolColorArray(colors: PoolColorArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_AABB(aabb: AABB)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolIntArray(ints: PoolIntArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Dictionary({})" time="0"></testcase>
+		<testcase name="When calling asserts.is_Transform(transform2D: Transform2D)" time="0"></testcase>
+		<testcase name="When calling asserts.is_RID(rid: RID)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Vector2(vec2)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Vector3(vec3: Vector3" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolVector2Array(vec2s: PoolVector2Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_string(strs: String)" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolStringArray(strs: PoolStringArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Rect2(rect2: Rect2)" time="0"></testcase>
 		<testcase name="When calling asserts.is_Transform(transform: Transform)" time="0"></testcase>
 		<testcase name="When calling is asserts.is_PoolVector3Array(vec3s: PoolVector3Array)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Vector3(vec3: Vector3" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolByteArray(bytes: PoolByteArray)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolVector2Array(vec2s: PoolVector2Array)" time="0"></testcase>
-		<testcase name="When calling is asserts.object(node: Node)" time="0"></testcase>
-		<testcase name="When calling asserts.is_RID(rid: RID)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Plane(plane: Plane())" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolIntArray(ints: PoolIntArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Vector2(vec2)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given an Is Not Instance of class/type Assertion" failures="0"  tests="26" time="0">
-		<testcase name="when calling asserts.is_not_float(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolIntArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_AABB(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_NodePath(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolVector2Array(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolVector3Array(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Basis(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_int(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolByteArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolRealArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolStringArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Quat(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Rect2(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_RID(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Color(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_String(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Plane(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_bool(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_PoolColorArray(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Transform(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Object(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Transform2D(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Dictionary(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Array(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Vector3(null)" time="0"></testcase>
-		<testcase name="when calling asserts.is_not_Vector2(null)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Null Assertion" failures="0"  tests="3" time="0">
-		<testcase name="When calling Node is not null" time="0"></testcase>
-		<testcase name="When calling freed object is null" time="0"></testcase>
-		<testcase name="When calling asserts.is_null(null)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given an Object Assertion" failures="0"  tests="15" time="0">
-		<testcase name="When calling asserts.object_has_meta with real key but null val" time="0"></testcase>
-		<testcase name="When calling has_method('title')" time="0"></testcase>
-		<testcase name="When calling asserts.is_not_freed(unfreed_object)" time="0"></testcase>
-		<testcase name="When calling asserts.is_freed(freed_object" time="0"></testcase>
-		<testcase name="When calling asserts.object_has_meta() after adding metadata" time="0"></testcase>
-		<testcase name="When calling asserts.object_does_not_have_meta()" time="0"></testcase>
-		<testcase name="When calling obj_has_user_signal after adding a signal" time="0"></testcase>
-		<testcase name="When calling asserts object is not connected with an invalid connection" time="0"></testcase>
-		<testcase name="When calling is blocking signals while blocking signals" time="0"></testcase>
-		<testcase name="When calling asserts.object_is_not_for_queued_deletion after not calling queue free()" time="0"></testcase>
-		<testcase name="When calling does not have user signal with class signal" time="0"></testcase>
-		<testcase name="When calling obj_does_not_have_user_signal with fake signal" time="0"></testcase>
-		<testcase name="When calling is not blocking signals while not blocking signals" time="0"></testcase>
-		<testcase name="When calling asserts.object_is_queued for deletion after calling queue_free" time="0"></testcase>
-		<testcase name="When calling asserts object is connected with a valid connection" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given the Addition Operator" failures="0"  tests="6" time="0">
-		<testcase name="When we subtract 2 from 2 we get 0" time="0"></testcase>
-		<testcase name="When we subtract 5 from 3 we get 2" time="0"></testcase>
-		<testcase name="When we subtract 7 from 6 we get 1" time="0"></testcase>
-		<testcase name="When we add 2 to 2 we get 4" time="0"></testcase>
-		<testcase name="When we add 5 to 3 we get 8" time="0"></testcase>
-		<testcase name="When we add 7 to 6 we get 13" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given A Range Assertion" failures="0"  tests="2" time="0">
-		<testcase name="When calling is (0) in range(0, 10)" time="0"></testcase>
-		<testcase name="When calling is (10) not in range (in range(0, 10)" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a String Assertion" failures="0"  tests="6" time="0">
-		<testcase name="When calling asserts.string_does_not_end_with('lorem', 'impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_ends_with('impsum', 'lorem impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_begins_with('lorem', 'lorem impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_contains('em im', 'lorem impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_does_not_contain('em im', 'impsum')" time="0"></testcase>
-		<testcase name="When calling asserts.string_does_not_begin_with('lorem', 'impsum')" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="" failures="0"  tests="1" time="0">
-		<testcase name=" simple" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Test Script" failures="0"  tests="3" time="0">
-		<testcase name="When we record properties" time="0"></testcase>
-		<testcase name=" we can omit describe" time="0"></testcase>
-		<testcase name=" when we omit context we can see expected and got under method" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Signal Watcher" failures="0"  tests="4" time="0">
-		<testcase name="When we watch and signal and emit it multiple times" time="0"></testcase>
-		<testcase name="When we watch and do not emit a signal" time="0"></testcase>
-		<testcase name="When we watch and emit a signal" time="0"></testcase>
-		<testcase name="When we watch a signal from an object with no bound variables" time="0"></testcase>
-	</testsuite>
-
-	<testsuite name="Given a Yield" failures="0"  tests="11" time="0">
-		<testcase name="When a signal being yielded on is emitted" time="0"></testcase>
-		<testcase name="When we yield in start twice" time="0"></testcase>
-		<testcase name="When we yield twice in execute" time="0"></testcase>
-		<testcase name="When asserting against a test" time="0"></testcase>
-		<testcase name="When it is finished" time="0"></testcase>
-		<testcase name="When we call until_timeout (with 1.0)" time="0"></testcase>
-		<testcase name="When we yield in pre thrice" time="0"></testcase>
-		<testcase name="When yield(self.yield_value()) returns" time="0"></testcase>
-		<testcase name="When the yielder heres our signal" time="0"></testcase>
-		<testcase name="When the yielder times out on until_timeout(0.1)" time="0"></testcase>
-		<testcase name="When we call until signal" time="0"></testcase>
+		<testcase name="When calling asserts.is_Quat(quat: Quat)" time="0"></testcase>
 	</testsuite>
 
 </testsuites>

--- a/tests/results.xml
+++ b/tests/results.xml
@@ -1,32 +1,222 @@
 <?xml version="1.0" ?>
-<testsuites failures="0" name="TestXML" tests="1" time="0">
+<testsuites failures="0" name="TestXML" tests="22" time="0">
+	<testsuite name="Default Args" failures="0"  tests="1" time="0">
+		<testcase name=" default arguments of interpolate property" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given is_on_floor" failures="0"  tests="3" time="0">
+		<testcase name="From a built-in KinematicBody2D2" time="0"></testcase>
+		<testcase name="From a user-defined script" time="0"></testcase>
+		<testcase name="From a child node of a scene without scripts" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Scene Director" failures="0"  tests="5" time="0">
+		<testcase name="When we call a method from a child node that we stubbed" time="0"></testcase>
+		<testcase name="When we call a method from the root node that we stubbed" time="0"></testcase>
+		<testcase name="When we add it to the tree it runs" time="0"></testcase>
+		<testcase name="When we create two of it for the same scene" time="0"></testcase>
+		<testcase name="When we call a method from a grandchild node that we stubbed" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Script Director" failures="0"  tests="3" time="0">
+		<testcase name="When we create two of it for the same script" time="0"></testcase>
+		<testcase name="When we call the double the second time" time="0"></testcase>
+		<testcase name="When we double an inner class" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Test Double" failures="0"  tests="19" time="0">
+		<testcase name="When we double an inner class" time="0"></testcase>
+		<testcase name="When we call a method that we have dummied" time="0"></testcase>
+		<testcase name="When we add an doubled inner class to it" time="0"></testcase>
+		<testcase name="When we call a method that we have stubbed to return a node" time="0"></testcase>
+		<testcase name="When we pass in dependecies on double" time="0"></testcase>
+		<testcase name="When we pass in dependecies on direct" time="0"></testcase>
+		<testcase name="When we call a method that we are spying on" time="0"></testcase>
+		<testcase name="When we call a method that was stubbed with an argument pattern that includes a non-primitive object" time="0"></testcase>
+		<testcase name="When we pass arguments to a method call that we are spying on" time="0"></testcase>
+		<testcase name="When we call a method that we have stubbed to return true" time="0"></testcase>
+		<testcase name="When we call an add(x, y) method that we haven't directed" time="0"></testcase>
+		<testcase name="When we call a method that was stubbed to return different values based on argument patterns" time="0"></testcase>
+		<testcase name="When we pass an Object with a call_func function" time="0"></testcase>
+		<testcase name="When we stubbed a keyworded method by passing in the correct keyword" time="0"></testcase>
+		<testcase name="When we pass a funcref as a subcall" time="0"></testcase>
+		<testcase name="When we call a method that we stubbed to call its super implementation by default" time="0"></testcase>
+		<testcase name="When we pass a funcref as a subcall that returns" time="0"></testcase>
+		<testcase name="When we call a method that was stubbed with a partial (ie using any()) argument pattern" time="0"></testcase>
+		<testcase name="When we stub a method of a doubled inner class" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Assertthat" failures="0"  tests="1" time="0">
+		<testcase name=" assert that" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Boolean Assertion" failures="0"  tests="2" time="0">
+		<testcase name="When calling asserts.is_true(true)" time="0"></testcase>
+		<testcase name="When calling asserts.is_false(false)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given an Equality Assertion" failures="0"  tests="7" time="0">
+		<testcase name="When calling asserts.is_equal_or_greater_than(2, 1)" time="0"></testcase>
+		<testcase name="When callign asserts.is_not_equal(5, 6)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal_or_less_than(1, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_greater_than(2, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal(1, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_less_than(2, 1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_equal_or_greater_than(1, 1)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Example" failures="0"  tests="1" time="0">
+		<testcase name=" simple" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A File Assertion" failures="0"  tests="3" time="0">
+		<testcase name="When calling asserts file does not exist when path is empty" time="0"></testcase>
+		<testcase name="When calling asserts.file_does_not_exist when there is no file" time="0"></testcase>
+		<testcase name="When calling asserts.file_exists when the file is this suite" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Has" failures="0"  tests="5" time="0">
+		<testcase name=" dict does not have value" time="0"></testcase>
+		<testcase name=" dict does not have key" time="0"></testcase>
+		<testcase name=" array does not have value" time="0"></testcase>
+		<testcase name=" array has value" time="0"></testcase>
+		<testcase name=" dict has key" time="0"></testcase>
+	</testsuite>
+
 	<testsuite name="Given an Is Instance of class/type Assertion" failures="0"  tests="26" time="0">
-		<testcase name="When calling asserts.is_NodePath(@'Parent/Child')" time="0"></testcase>
-		<testcase name="When calling is asserts.object(node: Node)" time="0"></testcase>
 		<testcase name="When calling is asserts.is_PoolRealArray(reals: PoolRealArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_color(color: Color)" time="0"></testcase>
-		<testcase name="When calling asserts.is_basis(basis: Basis" time="0"></testcase>
-		<testcase name="When calling asserts.is_float(1.0)" time="0"></testcase>
-		<testcase name="When callign asserts.is_int(1)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Array(array: Array)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Plane(plane: Plane())" time="0"></testcase>
 		<testcase name="When calling asserts.is_bool(true)" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolByteArray(bytes: PoolByteArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolColorArray(colors: PoolColorArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_AABB(aabb: AABB)" time="0"></testcase>
-		<testcase name="When calling asserts.is_PoolIntArray(ints: PoolIntArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Dictionary({})" time="0"></testcase>
-		<testcase name="When calling asserts.is_Transform(transform2D: Transform2D)" time="0"></testcase>
-		<testcase name="When calling asserts.is_RID(rid: RID)" time="0"></testcase>
 		<testcase name="When calling asserts.is_Vector2(vec2)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Vector3(vec3: Vector3" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolVector2Array(vec2s: PoolVector2Array)" time="0"></testcase>
-		<testcase name="When calling asserts.is_string(strs: String)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolStringArray(strs: PoolStringArray)" time="0"></testcase>
-		<testcase name="When calling asserts.is_Rect2(rect2: Rect2)" time="0"></testcase>
+		<testcase name="When calling asserts.is_float(1.0)" time="0"></testcase>
+		<testcase name="When calling asserts.is_AABB(aabb: AABB)" time="0"></testcase>
 		<testcase name="When calling asserts.is_Transform(transform: Transform)" time="0"></testcase>
-		<testcase name="When calling is asserts.is_PoolVector3Array(vec3s: PoolVector3Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolColorArray(colors: PoolColorArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_NodePath(@'Parent/Child')" time="0"></testcase>
+		<testcase name="When calling asserts.is_Dictionary({})" time="0"></testcase>
+		<testcase name="When calling is asserts.object(node: Node)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Plane(plane: Plane())" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolVector2Array(vec2s: PoolVector2Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_RID(rid: RID)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolByteArray(bytes: PoolByteArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_PoolIntArray(ints: PoolIntArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_basis(basis: Basis" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolStringArray(strs: PoolStringArray)" time="0"></testcase>
+		<testcase name="When calling asserts.is_color(color: Color)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Array(array: Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Vector3(vec3: Vector3" time="0"></testcase>
 		<testcase name="When calling asserts.is_Quat(quat: Quat)" time="0"></testcase>
+		<testcase name="When callign asserts.is_int(1)" time="0"></testcase>
+		<testcase name="When calling asserts.is_string(strs: String)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Transform(transform2D: Transform2D)" time="0"></testcase>
+		<testcase name="When calling is asserts.is_PoolVector3Array(vec3s: PoolVector3Array)" time="0"></testcase>
+		<testcase name="When calling asserts.is_Rect2(rect2: Rect2)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given an Is Not Instance of class/type Assertion" failures="0"  tests="26" time="0">
+		<testcase name="when calling asserts.is_not_Array(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_AABB(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Plane(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolByteArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Color(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolColorArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolIntArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Object(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolRealArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolStringArray(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolVector2Array(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_PoolVector3Array(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Quat(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_RID(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_String(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_NodePath(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Basis(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_int(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Dictionary(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Rect2(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_bool(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_float(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Vector3(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Vector2(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Transform2D(null)" time="0"></testcase>
+		<testcase name="when calling asserts.is_not_Transform(null)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Null Assertion" failures="0"  tests="3" time="0">
+		<testcase name="When calling freed object is null" time="0"></testcase>
+		<testcase name="When calling Node is not null" time="0"></testcase>
+		<testcase name="When calling asserts.is_null(null)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given an Object Assertion" failures="0"  tests="15" time="0">
+		<testcase name="When calling obj_has_user_signal after adding a signal" time="0"></testcase>
+		<testcase name="When calling asserts.object_does_not_have_meta()" time="0"></testcase>
+		<testcase name="When calling does not have user signal with class signal" time="0"></testcase>
+		<testcase name="When calling asserts.is_freed(freed_object" time="0"></testcase>
+		<testcase name="When calling is blocking signals while blocking signals" time="0"></testcase>
+		<testcase name="When calling asserts.object_has_meta() after adding metadata" time="0"></testcase>
+		<testcase name="When calling asserts object is connected with a valid connection" time="0"></testcase>
+		<testcase name="When calling asserts object is not connected with an invalid connection" time="0"></testcase>
+		<testcase name="When calling asserts.object_is_not_for_queued_deletion after not calling queue free()" time="0"></testcase>
+		<testcase name="When calling has_method('title')" time="0"></testcase>
+		<testcase name="When calling asserts.object_is_queued for deletion after calling queue_free" time="0"></testcase>
+		<testcase name="When calling is not blocking signals while not blocking signals" time="0"></testcase>
+		<testcase name="When calling obj_does_not_have_user_signal with fake signal" time="0"></testcase>
+		<testcase name="When calling asserts.is_not_freed(unfreed_object)" time="0"></testcase>
+		<testcase name="When calling asserts.object_has_meta with real key but null val" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given the Addition Operator" failures="0"  tests="6" time="0">
+		<testcase name="When we subtract 2 from 2 we get 0" time="0"></testcase>
+		<testcase name="When we subtract 5 from 3 we get 2" time="0"></testcase>
+		<testcase name="When we subtract 7 from 6 we get 1" time="0"></testcase>
+		<testcase name="When we add 2 to 2 we get 4" time="0"></testcase>
+		<testcase name="When we add 5 to 3 we get 8" time="0"></testcase>
+		<testcase name="When we add 7 to 6 we get 13" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given A Range Assertion" failures="0"  tests="2" time="0">
+		<testcase name="When calling is (0) in range(0, 10)" time="0"></testcase>
+		<testcase name="When calling is (10) not in range (in range(0, 10)" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a String Assertion" failures="0"  tests="6" time="0">
+		<testcase name="When calling asserts.string_does_not_begin_with('lorem', 'impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_contains('em im', 'lorem impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_does_not_end_with('lorem', 'impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_begins_with('lorem', 'lorem impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_ends_with('impsum', 'lorem impsum')" time="0"></testcase>
+		<testcase name="When calling asserts.string_does_not_contain('em im', 'impsum')" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Supersimple" failures="0"  tests="1" time="0">
+		<testcase name=" simple" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Test Script" failures="0"  tests="3" time="0">
+		<testcase name=" we can omit describe" time="0"></testcase>
+		<testcase name="When we record properties" time="0"></testcase>
+		<testcase name=" when we omit context we can see expected and got under method" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Signal Watcher" failures="0"  tests="4" time="0">
+		<testcase name="When we watch and signal and emit it multiple times" time="0"></testcase>
+		<testcase name="When we watch a signal from an object with no bound variables" time="0"></testcase>
+		<testcase name="When we watch and emit a signal" time="0"></testcase>
+		<testcase name="When we watch and do not emit a signal" time="0"></testcase>
+	</testsuite>
+
+	<testsuite name="Given a Yield" failures="0"  tests="11" time="0">
+		<testcase name="When yield(self.yield_value()) returns" time="0"></testcase>
+		<testcase name="When we yield twice in execute" time="0"></testcase>
+		<testcase name="When asserting against a test" time="0"></testcase>
+		<testcase name="When it is finished" time="0"></testcase>
+		<testcase name="When we call until signal" time="0"></testcase>
+		<testcase name="When we yield in start twice" time="0"></testcase>
+		<testcase name="When a signal being yielded on is emitted" time="0"></testcase>
+		<testcase name="When the yielder heres our signal" time="0"></testcase>
+		<testcase name="When the yielder times out on until_timeout(0.1)" time="0"></testcase>
+		<testcase name="When we call until_timeout (with 1.0)" time="0"></testcase>
+		<testcase name="When we yield in pre thrice" time="0"></testcase>
 	</testsuite>
 
 </testsuites>


### PR DESCRIPTION
Implemented icon scaling for the "Select Test" options menu.
Changed `plugin_asset_registry.gd` to support running without an editor plugin, which lets icons load when the Tests UI is run outside of the editor.
Disabled the "Run Debug" options when running the Tests UI outside of the editor since the Tests UI is already outside the editor.

Stanalone UI:
![StandaloneTestsUIGDScript](https://user-images.githubusercontent.com/25368491/117547871-ec3eec00-afff-11eb-97e4-b3713b553b50.png)

Inside Editor UI:
![EditorTestsUIGDScript](https://user-images.githubusercontent.com/25368491/117547872-ecd78280-afff-11eb-9ed9-7527309866c7.png)
